### PR TITLE
Perform a long-overdue update to the CoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,27 @@
-# Open Source Code of Conduct
+# Kinetic Commerce Open Source Code of Conduct
 
 This repository contains the Open Source [Code of Conduct][] used in
-[KineticCafe][] open source projects.
+[KineticCafe][] open source projects, administered by Kinetic Commerce.
+
+The [code-of-conduct.md](./code-of-conduct.md) file will be moved to
+<https://github.com/KineticCafe/.github/blob/main/code-of-conduct.md> in the
+near future.
 
 # License
 
-This Code Of Conduct is based on the [@TwitterOSS Code of Conduct][] and [Open
-Code of Conduct][], and is licensed under a [Creative Commons
-Attribution License][CC-BY-4.0].
+This Code of Conduct is licensed under a [Creative Commons Attribution
+License][cc-by-4.0].
 
-For attribution requirements:
+For attribution requirements, use:
 
-"Kinetic Cafe Code of Conduct" © 2016 Kinetic Cafe, Inc, used under a Creative
-Commons Attribution International 4.0
+```text
+"Kinetic Commerce Code of Conduct" © 2016–2024 Kinetic Commerce, used under
+a Creative Commons Attribution International 4.0
 (http://creativecommons.org/licenses/by/4.0/) license.
+```
 
-[Code of Conduct]: https://github.com/KineticCafe/code-of-conduct/blob/master/code-of-conduct.md
-[KineticCafe]: https://github.com/KineticCafe
-[@TwitterOSS Code of Conduct]: https://github.com/twitter/code-of-conduct
-[CC-BY-4.0]: http://creativecommons.org/licenses/by/4.0/
-[Open Code of Conduct]: https://github.com/todogroup/opencodeofconduct
+[@twitteross code of conduct]: https://github.com/twitter-archive/code-of-conduct
+[cc-by-4.0]: http://creativecommons.org/licenses/by/4.0/
+[code of conduct]: https://github.com/KineticCafe/code-of-conduct/blob/main/code-of-conduct.md
+[kineticcafe]: https://github.com/KineticCafe
+[open code of conduct]: https://github.com/todogroup/opencodeofconduct

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,103 +1,121 @@
-# Code of Conduct
+# Kinetic Commerce Open Source Code of Conduct
 
-Version 1.0
+Version 2.0
 
-This code of conduct outlines our expectations for participants within the
-[Kinetic Cafe][kineticcafe] open source community, as well as steps to
-reporting unacceptable behavior. We are committed to providing a welcoming and
-inspiring community for all and expect our code of conduct to be honored.
-Anyone who violates this code of conduct may be banned from the community.
+This code of conduct outlines our expectations for participating in Kinetic
+Commerce [open source projects][kineticcafe], as well as steps to reporting
+unacceptable behaviour.
 
-Our open source community strives to:
+We are committed to providing a welcoming and inspiring community for all and
+expect our code of conduct to be honored. Anyone who violates this code of
+conduct may be banned from participation on one or more Kinetic Commerce open
+source projects.
 
-*   **Be friendly and patient.**
+We strive to:
 
-*   **Be welcoming**: We strive to be a community that welcomes and supports
-    people of all backgrounds and identities. This includes, but is not limited
-    to members of any race, ethnicity, culture, national origin, colour,
-    immigration status, social and economic class, educational level, sex,
-    sexual orientation, gender identity and expression, age, size, family
-    status, political belief, religion, and mental and physical ability.
+- **Be friendly and patient.**
 
-*   **Be considerate**: Your work will be used by other people, and you in turn
-    will depend on the work of others. Any decision you take will affect users
-    and colleagues, and you should take those consequences into account when
-    making decisions. Remember that we're a world-wide community, so you might
-    not be communicating in someone else's primary language.
+- **Be welcoming**: We strive to make participation in our projects
+  a harassment-free experience for everyone, regardless of age, body size,
+  caste, color, culture, education, ethnicity, family status, gender identity
+  and expression, language, immigration status, level of experience, national
+  origin, personal appearance, political beliefs, profession, race, religion,
+  sex characteristics, sexual identity and orientation, socio-economic status,
+  or visible or invisible disability.
 
-*   **Be respectful**:  Not all of us will agree all the time, but disagreement
-    is no excuse for poor behavior and poor manners. We might all experience
-    some frustration now and then, but we cannot allow that frustration to turn
-    into a personal attack. It’s important to remember that a community where
-    people feel uncomfortable or threatened is not a productive one.
+- **Be considerate**: Your work will be used by other people, and you in turn
+  will depend on the work of others. Any decision you take will affect users
+  and colleagues, and you should take those consequences into account when
+  making decisions. Remember that we're a world-wide community, so you might
+  not be communicating in someone else's primary language.
 
-*   **Be careful in the words that you choose**: we are a community of
-    professionals, and we conduct ourselves professionally. Be kind to others.
-    Do not insult or put down other participants. Harassment and other
-    exclusionary behavior aren't acceptable. This includes, but is not limited
-    to:
+- **Be respectful**: Not all of us will agree all the time, but disagreement
+  is no excuse for poor behavior or poor manners. We all experience some
+  frustration now and then, but we cannot allow that to turn into personal
+  attacks. It's important to remember that a community where people feel
+  uncomfortable or threatened is not a productive one.
 
-    *   Violent threats or language directed against another person.
-    *   Discriminatory jokes and language.
-    *   Posting sexually explicit or violent material.
-    *   Posting (or threatening to post) other people's personally identifying
-        information ("doxing").
-    *   Personal insults, especially those using racist or sexist terms.
-    *   Unwelcome sexual attention.
-    *   Advocating for, or encouraging, any of the above behavior.
-    *   Repeated harassment of others. In general, if someone asks you to stop,
-        then stop.
+- **Be careful in the words that you choose**: we are a community of
+  professionals, and we conduct ourselves professionally. Be kind to others.
+  Do not insult or put down other participants. Harassment and other
+  exclusionary behavior aren't acceptable.
 
-*   **When we disagree, try to understand why**: Disagreements, both social and
-    technical, happen all the time. It is important that we resolve
-    disagreements and differing views constructively. Remember that we’re
-    different. The strength of our community comes from its diversity, people
-    from a wide range of backgrounds. Different people have different
-    perspectives on issues. Being unable to understand why someone holds a
-    viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to
-    err and blaming each other doesn’t get us anywhere. Instead, focus on
-    helping to resolve issues and learning from mistakes.
+  Behaviours that contribute to a positive environment include:
+
+  - Demonstrating empathy and kindness toward other people
+  - Being respectful of differing opinions, viewpoints, and experiences
+  - Giving and gracefully accepting constructive feedback
+  - Accepting responsibility and apologizing to those affected by our
+    mistakes, and learning from the experience
+  - Focusing on what is best not just for us as individuals, but for the
+    overall community
+
+  Unacceptable behaviours include, but are not limited to:
+
+  - The use of sexualized language or imagery, and sexual attention or
+    advances of any kind
+  - Trolling, insulting or derogatory comments, and personal or political
+    attacks
+  - Public or private harassment
+  - Publishing others' private information, such as a physical or email
+    address, without their explicit permission
+  - Other conduct which could reasonably be considered inappropriate in a
+    professional setting
+  - Violent threats or language directed against another person
+  - Discriminatory jokes and language
+  - Advocating for, or encouraging, any of the above behavior
+
+* **When we disagree, try to understand why**: Disagreements, both social and
+  technical, happen all the time. It is important that we resolve
+  disagreements constructively. Remember that we're different. The strength of
+  our community comes from its diversity. People from a wide range of
+  backgrounds and may have different perspectives on issues. Being unable to
+  understand why someone holds a viewpoint doesn't mean that they're wrong.
+  Don't forget that it is human to err and blaming each other doesn't get us
+  anywhere. Instead, focus on helping to resolve issues and learning from
+  mistakes.
 
 This code is not exhaustive or complete. It serves to distill our common
 understanding of a collaborative, shared environment, and goals. We expect it
 to be followed in spirit as much as in the letter.
 
-### Diversity Statement
+## Diversity Statement
 
 We encourage everyone to participate and are committed to building a community
 for all. Although we may not be able to satisfy everyone, we all agree that
-everyone is equal. Whenever a participant has made a mistake, we expect them to
-take responsibility for it. If someone has been harmed or offended, it is our
-responsibility to listen carefully and respectfully, and do our best to right
-the wrong.
+everyone is equal. Whenever a participant has made a mistake, we expect them
+to take responsibility for it. If someone has been harmed or offended, it is
+our responsibility to listen carefully and respectfully, and do our best to
+right the wrong.
 
 Although this list cannot be exhaustive, we explicitly honor diversity in age,
-gender, gender identity or expression, culture, ethnicity, language, national
-origin, political beliefs, profession, race, religion, sexual orientation,
-socioeconomic status, and technical ability. We will not tolerate
-discrimination based on any of the protected characteristics above, including
-participants with disabilities.
+body size, caste, color, culture, education, ethnicity, family status, gender
+identity and expression, language, immigration status, level of experience,
+national origin, personal appearance, political beliefs, profession, race,
+religion, sex characteristics, sexual identity and orientation, socio-economic
+status, or visible or invisible disability. We will not tolerate
+discrimination based on any of the characteristics above.
 
-### Reporting Issues
+## Reporting Issues
 
 If you experience or witness unacceptable behavior—or have any other concerns—
 please report it by contacting us via
-[opensource-codeofconduct@kineticcafe.com][]. All reports will be handled with
-discretion. In your report please include:
+[opensource-codeofconduct@kineticcommerce.com][]. All reports will be handled
+with discretion. In your report please include:
 
--   Your contact information.
--   Names (real, nicknames, or pseudonyms) of any individuals involved. If
-    there are additional witnesses, please include them as well. Your account
-    of what occurred, and if you believe the incident is ongoing. If there is a
-    publicly available record (e.g. a mailing list archive or a public IRC
-    logger), please include a link.
--   Any additional information that may be helpful.
+- Your contact information.
+- Names (real, nicknames, or pseudonyms) of any individuals involved. If
+  there are additional witnesses, please include them as well. Your account
+  of what occurred, and if you believe the incident is ongoing. If there is a
+  publicly available record (e.g. a mailing list archive or a public IRC
+  logger), please include a link.
+- Any additional information that may be helpful.
 
-After filing a report, a representative will contact you personally. If the
-person who is harassing you is part of the response team, they will recuse
-themselves from handling your incident. A representative will then review the
-incident, follow up with any additional questions, and make a decision as to
-how to respond. We will respect confidentiality requests for the purpose of
+After filing a report, someone will contact you personally. If the person who
+is harassing you is part of the response team, they will recuse themselves
+from handling your incident. A representative will then review the incident,
+follow up with any additional questions, and make a decision as to how to
+respond. We will respect confidentiality requests for the purpose of
 protecting victims of abuse.
 
 Anyone asked to stop unacceptable behavior is expected to comply immediately.
@@ -105,16 +123,82 @@ If an individual engages in unacceptable behavior, the representative may take
 any action they deem appropriate, up to and including a permanent ban from our
 community without warning.
 
+### Enforcement Guidelines
+
+Kinetic Commerce uses the following impact guidelines to determine the
+consequences of actions they are reported or are observed and are deemed in
+violation of this Code of Conduct:
+
+#### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+#### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+#### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited
+interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+#### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
 ## Thanks
 
-This code of conduct is based on both [@TwitterOSS Code of Conduct][] and the
-[Open Code of Conduct][] from the [TODOGroup][].
+This code of conduct is originally based on the [@TwitterOSS Code of
+Conduct][] and the [Open Code of Conduct][] (from the [TODOGroup][]).
 
-We are thankful for their work and all the communities who have paved the way
-with code of conducts.
+Version 2.0 of the Kinetic Commerce Code of Conduct has language adapted from
+the [Contributor Covenant][cc], version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
 
+We are thankful for the work of these organizations and all the communities
+who have paved the way with codes of conduct.
+
+### License and Attribution
+
+This Code Of Conduct is licensed under a [Creative Commons Attribution
+License][cc-by-4.0].
+
+For attribution requirements, use:
+
+```text
+"Kinetic Commerce Code of Conduct" © 2016–2024 Kinetic Commerce, used under
+a Creative Commons Attribution International 4.0
+(http://creativecommons.org/licenses/by/4.0/) license.
+```
+
+[@twitteross code of conduct]: https://github.com/twitter/code-of-conduct
+[cc-by-4.0]: http://creativecommons.org/licenses/by/4.0/
+[cc]: https://www.contributor-covenant.org
 [kineticcafe]: https://github.com/KineticCafe
-[opensource-codeofconduct@kineticcafe.com]: mailto:opensource-codeofconduct@kineticcafe.com
-[Open Code of Conduct]: https://github.com/todogroup/opencodeofconduct
-[TODOGroup]: http://todogroup.org
-[@TwitterOSS Code of Conduct]: https://github.com/twitter/code-of-conduct
+[open code of conduct]: https://github.com/todogroup/opencodeofconduct
+[opensource-codeofconduct@kineticcommerce.com]: mailto:opensource-codeofconduct@kineticcommerce.com
+[todogroup]: http://todogroup.org


### PR DESCRIPTION
We have always referred to this as the Kinetic Cafe code of conduct, but that company no longer exists. We use github.com/KineticCafe to host our open source repositories, but this is the Kinetic Commerce code of conduct which will be enforced by employees of Kinetic Commerce.

While updating this, we changed some of the wording to try to better reflect that any enforcement will be at a *repository* ("project") level first and foremost, but may expand to participation in all KineticCafe repositories. We are not an OSS community like Mozilla, Debian, or even the former Twitter open source community where there were employees whose full-time job was to manage the open source contributions of their employees and external contributors (often requiring the acceptance of contributor licensing agreements).

We have had some contributions in the past to our open source projects, but very few.

Review of the most recent version of the Contributor Covenant offers some useful wording updates to be *clearer* on acceptable and unacceptable behaviours as well as enforcement stages. These changes are drastic enough that it was worthwhile marking a major version bump.